### PR TITLE
Fix GUI calibration: full-desktop capture + right-click window/monitor select

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -64,6 +64,9 @@ struct Preview {
     texture: egui::TextureHandle,
     /// Display size in points (fits the panel).
     shown: egui::Vec2,
+    /// Where the image is actually drawn this frame (set by the tab that
+    /// renders it) — used to map display-space drags to image pixels.
+    rect: egui::Rect,
 }
 struct LittleOilGui {
     app: Arc<App>,
@@ -74,6 +77,9 @@ struct LittleOilGui {
     preview: Option<Preview>,
     /// Drag rectangle in *display* space (shown image coords), when active.
     drag: Option<(egui::Pos2, egui::Pos2)>,
+    /// Screen point of the last right-click on the preview (for the
+    /// "select whole window/monitor" context menu).
+    right_click_screen: Option<(i32, i32)>,
     region_target: RegionTarget,
     show_inv_overlay: bool,
     status: String,
@@ -98,6 +104,7 @@ impl LittleOilGui {
             tab: "Actions",
             preview: None,
             drag: None,
+            right_click_screen: None,
             region_target: RegionTarget::Game,
             show_inv_overlay: false,
             status: String::new(),
@@ -157,8 +164,9 @@ impl LittleOilGui {
     }
 
     fn capture_preview(&mut self, ctx: &egui::Context) {
-        let settings = self.app.settings.read().clone();
-        match settings.screenshot() {
+        // Calibration preview: capture the whole desktop, not the current
+        // game-window region, so any region can be dragged and selected.
+        match self.app.platform().capture_desktop() {
             Ok(data) => {
                 let (w, h) = (data.width, data.height);
                 let (ox, oy) = data.origin;
@@ -170,56 +178,57 @@ impl LittleOilGui {
                     data,
                     texture,
                     shown,
+                    rect: egui::Rect::ZERO, // set by the tab that draws it
                 });
-                self.push(format!("captured {w}x{h} (origin {ox}, {oy})"));
+                self.push(format!("captured desktop {w}x{h} (origin {ox}, {oy})"));
             }
             Err(e) => self.push(format!("capture failed: {e:#}")),
         }
     }
 
+    /// Convert a display-space point to image-pixel coords using the rect the
+    /// image is actually drawn in.
+    fn display_to_image(&self, p: egui::Pos2) -> Option<(u32, u32)> {
+        let preview = self.preview.as_ref()?;
+        let rect = preview.rect;
+        let px = (p.x - rect.min.x) / rect.width() * preview.data.width as f32;
+        let py = (p.y - rect.min.y) / rect.height() * preview.data.height as f32;
+        if px < 0.0 || py < 0.0 || px > preview.data.width as f32 || py > preview.data.height as f32
+        {
+            return None;
+        }
+        Some((px as u32, py as u32))
+    }
+
     /// Convert a drag rect in display space to a screen-space region.
     fn drag_to_region(&self, a: egui::Pos2, b: egui::Pos2) -> Option<ScreenRegion> {
         let preview = self.preview.as_ref()?;
-        let shown = fit_into(
-            egui::Vec2::new(preview.data.width as f32, preview.data.height as f32),
-            PREVIEW_AVAIL,
-        );
-        let origin_disp = egui::pos2(
-            (PREVIEW_AVAIL.x - shown.x) / 2.0,
-            (PREVIEW_AVAIL.y - shown.y) / 2.0,
-        );
-        let to_img = |p: egui::Pos2| -> Option<(u32, u32)> {
-            let px = (p.x - origin_disp.x) / shown.x * preview.data.width as f32;
-            let py = (p.y - origin_disp.y) / shown.y * preview.data.height as f32;
-            if px < 0.0
-                || py < 0.0
-                || px > preview.data.width as f32
-                || py > preview.data.height as f32
-            {
-                return None;
-            }
-            Some((px as u32, py as u32))
-        };
-        let (x0, y0) = to_img(a.min(b))?;
-        let (x1, y1) = to_img(a.max(b))?;
+        let (x0, y0) = self.display_to_image(a.min(b))?;
+        let (x1, y1) = self.display_to_image(a.max(b))?;
         let w = x1.saturating_sub(x0).max(1);
         let h = y1.saturating_sub(y0).max(1);
+        // Screen coordinates; the config region type is non-negative, so clamp
+        // origins left/above the primary monitor.
         Some(ScreenRegion {
-            x: preview.data.origin.0 + x0,
-            y: preview.data.origin.1 + y0,
+            x: (preview.data.origin.0 + x0 as i32).max(0) as u32,
+            y: (preview.data.origin.1 + y0 as i32).max(0) as u32,
             width: w,
             height: h,
         })
     }
 
-    fn save_dragged_region(&mut self) {
-        let Some((a, b)) = self.drag else { return };
-        self.drag = None;
-        let Some(region) = self.drag_to_region(a, b) else {
-            self.push("drag was outside the captured image — try again");
-            return;
-        };
-        let target = self.region_target;
+    /// Display-space point → screen coordinates (for the right-click menu).
+    fn screen_point_of(&self, p: egui::Pos2) -> Option<(i32, i32)> {
+        let preview = self.preview.as_ref()?;
+        let (ix, iy) = self.display_to_image(p)?;
+        Some((
+            preview.data.origin.0 + ix as i32,
+            preview.data.origin.1 + iy as i32,
+        ))
+    }
+
+    /// Write `region` into the settings field for `target` and persist.
+    fn apply_selected_region(&mut self, target: RegionTarget, region: ScreenRegion, what: &str) {
         {
             let mut s = self.app.settings.write();
             match target {
@@ -233,7 +242,7 @@ impl LittleOilGui {
         let path = config_path().unwrap_or_else(|_| "config.json".into());
         match save_config(&path, &settings_snapshot) {
             Ok(()) => self.push(format!(
-                "saved {} region: {}x{} at ({}, {})",
+                "{what} → {} region: {}x{} at ({}, {})",
                 target.label(),
                 region.width,
                 region.height,
@@ -241,6 +250,33 @@ impl LittleOilGui {
                 region.y
             )),
             Err(e) => self.push(format!("saved in memory but config write failed: {e:#}")),
+        }
+    }
+
+    fn save_dragged_region(&mut self) {
+        let Some((a, b)) = self.drag else { return };
+        self.drag = None;
+        let Some(region) = self.drag_to_region(a, b) else {
+            self.push("drag was outside the captured image — try again");
+            return;
+        };
+        let target = self.region_target;
+        self.apply_selected_region(target, region, "drag");
+    }
+
+    /// Right-click menu: select the whole window under the cursor.
+    fn select_whole_window(&mut self, sx: i32, sy: i32) {
+        match self.app.platform().window_under_point(sx, sy) {
+            Some(region) => self.apply_selected_region(self.region_target, region, "window"),
+            None => self.push("no window found under the cursor (unsupported compositor?)"),
+        }
+    }
+
+    /// Right-click menu: select the whole monitor under the cursor.
+    fn select_whole_monitor(&mut self, sx: i32, sy: i32) {
+        match self.app.platform().monitor_under_point(sx, sy) {
+            Some(region) => self.apply_selected_region(self.region_target, region, "monitor"),
+            None => self.push("no monitor found under the cursor"),
         }
     }
 
@@ -323,14 +359,24 @@ impl LittleOilGui {
             }
         });
         ui.add_space(4.0);
-        if let Some(prev) = &self.preview {
-            let (rect, response) = ui.allocate_exact_size(prev.shown, egui::Sense::drag());
-            ui.painter().image(
-                prev.texture.id(),
-                rect,
-                egui::Rect::from_min_max(egui::Pos2::ZERO, egui::Pos2::new(1.0, 1.0)),
-                egui::Color32::WHITE,
-            );
+        ui.label(
+            "Drag to select a region. Right-click the preview to select a whole window or monitor.",
+        );
+        if self.preview.is_some() {
+            // Short borrows only — the interaction handlers below take &mut self.
+            let shown = self.preview.as_ref().map(|p| p.shown).unwrap_or_default();
+            let (rect, response) = ui.allocate_exact_size(shown, egui::Sense::click_and_drag());
+            if let Some(prev) = &mut self.preview {
+                prev.rect = rect;
+            }
+            if let Some(prev) = &self.preview {
+                ui.painter().image(
+                    prev.texture.id(),
+                    rect,
+                    egui::Rect::from_min_max(egui::Pos2::ZERO, egui::Pos2::new(1.0, 1.0)),
+                    egui::Color32::WHITE,
+                );
+            }
             if response.drag_started() {
                 let pos = response.interact_pointer_pos().unwrap_or_default();
                 self.drag = Some((pos, pos));
@@ -348,6 +394,26 @@ impl LittleOilGui {
                 }
                 self.save_dragged_region();
             }
+            if response.secondary_clicked() {
+                self.right_click_screen = response
+                    .interact_pointer_pos()
+                    .and_then(|p| self.screen_point_of(p));
+            }
+            // Right-click context menu: select the whole window or monitor.
+            response.context_menu(|ui| {
+                if ui.button("Select whole window under cursor").clicked() {
+                    if let Some((sx, sy)) = self.right_click_screen {
+                        self.select_whole_window(sx, sy);
+                    }
+                    ui.close();
+                }
+                if ui.button("Select whole monitor under cursor").clicked() {
+                    if let Some((sx, sy)) = self.right_click_screen {
+                        self.select_whole_monitor(sx, sy);
+                    }
+                    ui.close();
+                }
+            });
             // Draw the drag overlay.
             if let Some((a, b)) = self.drag {
                 let r = egui::Rect::from_two_pos(a, b);

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -80,6 +80,50 @@ impl Platform {
         anyhow::bail!("capture_all: unsupported platform")
     }
 
+    /// Full virtual-desktop capture without the cursor. Used by the GUI
+    /// calibration preview so the whole screen can be seen and dragged over.
+    pub fn capture_desktop(&self) -> anyhow::Result<ScreenshotData> {
+        #[cfg(target_os = "linux")]
+        match self {
+            Platform::Wayland => wayland::capture_desktop(),
+            _ => anyhow::bail!("capture_desktop not implemented for platform {:?}", self),
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::capture_desktop()
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        anyhow::bail!("capture_desktop: unsupported platform")
+    }
+
+    /// Bounds of the window under a screen point. Used by the GUI's
+    /// right-click "select whole window" calibration shortcut.
+    pub fn window_under_point(&self, x: i32, y: i32) -> Option<ScreenRegion> {
+        #[cfg(target_os = "linux")]
+        if matches!(self, Platform::Wayland) {
+            return wayland::window_under_point(x, y);
+        }
+        #[cfg(target_os = "windows")]
+        if matches!(self, Platform::Windows) {
+            return windows::window_under_point(x, y);
+        }
+        None
+    }
+
+    /// Bounds of the monitor under a screen point. Used by the GUI's
+    /// right-click "select whole monitor" calibration shortcut.
+    pub fn monitor_under_point(&self, x: i32, y: i32) -> Option<ScreenRegion> {
+        #[cfg(target_os = "linux")]
+        if matches!(self, Platform::Wayland) {
+            return wayland::monitor_under_point(x, y);
+        }
+        #[cfg(target_os = "windows")]
+        if matches!(self, Platform::Windows) {
+            return windows::monitor_under_point(x, y);
+        }
+        None
+    }
+
     /// Returns `true` when the platform uses absolute pointer positioning
     /// (no `pointer_scale` needed). On Linux this is niri only (wlr virtual
     /// pointer). On Windows all positioning is absolute.

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -57,7 +57,21 @@ pub fn screenshot(settings: &Settings) -> anyhow::Result<ScreenshotData> {
         height: img.height() as usize,
         width: img.width() as usize,
         pixels: img.to_rgba8().to_vec(),
-        origin: (region.x, region.y),
+        origin: (region.x as i32, region.y as i32),
+    })
+}
+
+/// Capture the whole desktop (every output composited at origin 0,0), without
+/// the cursor. Used by the GUI calibration preview so any region can be
+/// dragged on screen.
+#[cfg(target_os = "linux")]
+pub fn capture_desktop() -> anyhow::Result<ScreenshotData> {
+    let img = grim_capture(None, false)?;
+    Ok(ScreenshotData {
+        height: img.height() as usize,
+        width: img.width() as usize,
+        pixels: img.to_rgba8().to_vec(),
+        origin: (0, 0),
     })
 }
 
@@ -73,6 +87,96 @@ pub fn capture_all_with_cursor() -> anyhow::Result<ScreenshotData> {
     })
 }
 
+/// Clamp raw window bounds into the non-negative screen-region type used by
+/// the config. `None` if the window is entirely off the positive area.
+#[cfg(target_os = "linux")]
+fn region_from_bounds(x: i32, y: i32, w: i32, h: i32) -> Option<ScreenRegion> {
+    if w <= 0 || h <= 0 {
+        return None;
+    }
+    // Intersect with the non-negative quadrant the config can represent.
+    let x0 = x.max(0) as u32;
+    let y0 = y.max(0) as u32;
+    let x1 = (x + w).max(0) as u32;
+    let y1 = (y + h).max(0) as u32;
+    if x1 <= x0 || y1 <= y0 {
+        return None;
+    }
+    Some(ScreenRegion {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    })
+}
+
+/// Bounds of the window under a screen point, via `hyprctl clients`.
+/// Compositors without hyprctl return None (the GUI shows a hint).
+#[cfg(target_os = "linux")]
+pub fn window_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
+    let out = std::process::Command::new("hyprctl")
+        .args(["clients", "-j"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let clients: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    for w in clients.as_array()?.iter() {
+        let Some(title) = w["title"].as_str() else {
+            continue;
+        };
+        if title.contains("Little Oil") {
+            continue; // our own window
+        }
+        let (Some(at), Some(size)) = (w["at"].as_array(), w["size"].as_array()) else {
+            continue;
+        };
+        let (Some(wx), Some(wy)) = (
+            at.first().and_then(|v| v.as_i64()),
+            at.get(1).and_then(|v| v.as_i64()),
+        ) else {
+            continue;
+        };
+        let (Some(ww), Some(wh)) = (
+            size.first().and_then(|v| v.as_i64()),
+            size.get(1).and_then(|v| v.as_i64()),
+        ) else {
+            continue;
+        };
+        let (wx, wy, ww, wh) = (wx as i32, wy as i32, ww as i32, wh as i32);
+        if x >= wx && x < wx + ww && y >= wy && y < wy + wh {
+            return region_from_bounds(wx, wy, ww, wh);
+        }
+    }
+    None
+}
+
+/// Bounds of the monitor under a screen point, via `hyprctl monitors`.
+#[cfg(target_os = "linux")]
+pub fn monitor_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
+    let out = std::process::Command::new("hyprctl")
+        .args(["monitors", "-j"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let monitors: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    for m in monitors.as_array()?.iter() {
+        let (Some(mx), Some(my)) = (m["x"].as_i64(), m["y"].as_i64()) else {
+            continue;
+        };
+        let (Some(mw), Some(mh)) = (m["width"].as_i64(), m["height"].as_i64()) else {
+            continue;
+        };
+        let (mx, my, mw, mh) = (mx as i32, my as i32, mw as i32, mh as i32);
+        if x >= mx && x < mx + mw && y >= my && y < my + mh {
+            return region_from_bounds(mx, my, mw, mh);
+        }
+    }
+    None
+}
 pub fn select_region(prompt: &str) -> anyhow::Result<ScreenRegion> {
     let _ = Command::new("notify-send")
         .args(["-u", "critical", "Little Oil", prompt])

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -257,14 +257,152 @@ pub fn screenshot(settings: &Settings) -> Result<ScreenshotData> {
         width: w,
         height: h,
         pixels,
-        origin: (ox as u32, oy as u32),
+        origin: (ox, oy),
     })
+}
+
+/// Full virtual-desktop capture (all monitors composited), no cursor. Used by
+/// the GUI calibration preview. BitBlt of the desktop DC reads the DWM
+/// composited screen; in exclusive-fullscreen games the game surface may read
+/// black — borderless/windowed modes (the PoE default) capture cleanly.
+pub fn capture_desktop() -> Result<ScreenshotData> {
+    unsafe {
+        use windows::Win32::Graphics::Gdi::{
+            BITMAPINFO, BITMAPINFOHEADER, BitBlt, CreateCompatibleBitmap, CreateCompatibleDC,
+            DIB_RGB_COLORS, DeleteDC, DeleteObject, GetDC, GetDIBits, ReleaseDC, SRCCOPY,
+            SelectObject,
+        };
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
+            SM_YVIRTUALSCREEN,
+        };
+        let vx = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        let vy = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        let w = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        let h = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        if w <= 0 || h <= 0 {
+            bail!("virtual screen size is {w}x{h} — cannot capture");
+        }
+
+        let screen_dc = GetDC(None);
+        let mem_dc = CreateCompatibleDC(None);
+        let bmp = CreateCompatibleBitmap(screen_dc, w, h);
+        if screen_dc.is_invalid() || mem_dc.is_invalid() || bmp.is_invalid() {
+            bail!("failed to create desktop capture surfaces");
+        }
+
+        let old = SelectObject(mem_dc, bmp.into());
+        // The screen DC is anchored at the primary monitor's (0,0); the virtual
+        // screen may extend left/up, so offset the source by (-vx, -vy).
+        BitBlt(mem_dc, 0, 0, w, h, Some(screen_dc), -vx, -vy, SRCCOPY).context("BitBlt failed")?;
+
+        let mut bmi = BITMAPINFO::default();
+        bmi.bmiHeader = BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: w,
+            biHeight: -h, // top-down rows
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: 0, // BI_RGB
+            ..Default::default()
+        };
+        let mut pixels = vec![0u8; (w as usize) * (h as usize) * 4];
+        let got = GetDIBits(
+            mem_dc,
+            bmp,
+            0,
+            h as u32,
+            Some(pixels.as_mut_ptr() as *mut core::ffi::c_void),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+        if got == 0 {
+            bail!("GetDIBits failed");
+        }
+
+        // 32bpp BI_RGB is BGRA little-endian; ScreenshotData is RGBA8.
+        for px in pixels.chunks_exact_mut(4) {
+            px.swap(0, 2);
+        }
+
+        let _ = SelectObject(mem_dc, old);
+        let _ = DeleteObject(bmp.into());
+        let _ = DeleteDC(mem_dc);
+        let _ = ReleaseDC(None, screen_dc);
+
+        Ok(ScreenshotData {
+            width: w as usize,
+            height: h as usize,
+            pixels,
+            origin: (vx, vy),
+        })
+    }
 }
 
 /// Full-desktop capture with cursor. Not implemented on Windows — only the
 /// Linux cursor-diff pointer calibration uses it.
 pub fn capture_all() -> Result<ScreenshotData> {
     bail!("capture_all is not implemented on Windows (only used by Linux pointer calibration)")
+}
+
+/// Bounds of the window under a screen point (`WindowFromPoint`).
+pub fn window_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
+    unsafe {
+        use windows::Win32::Foundation::{POINT, RECT};
+        use windows::Win32::UI::WindowsAndMessaging::{GetWindowRect, WindowFromPoint};
+        let hwnd = WindowFromPoint(POINT { x, y });
+        if hwnd.is_invalid() {
+            return None;
+        }
+        let mut r = RECT::default();
+        if GetWindowRect(hwnd, &mut r as *mut _).is_err() {
+            return None;
+        }
+        clamp_region(r.left, r.top, r.right - r.left, r.bottom - r.top)
+    }
+}
+
+/// Bounds of the monitor under a screen point (`MonitorFromPoint`).
+pub fn monitor_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
+    unsafe {
+        use windows::Win32::Foundation::POINT;
+        use windows::Win32::Graphics::Gdi::{
+            GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromPoint,
+        };
+        let hmon = MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST);
+        if hmon.is_invalid() {
+            return None;
+        }
+        let mut info = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..Default::default()
+        };
+        if GetMonitorInfoW(hmon, &mut info as *mut _).as_bool() == false {
+            return None;
+        }
+        let r = info.rcMonitor;
+        clamp_region(r.left, r.top, r.right - r.left, r.bottom - r.top)
+    }
+}
+
+/// Clamp window/monitor bounds into the non-negative `ScreenRegion` type.
+fn clamp_region(x: i32, y: i32, w: i32, h: i32) -> Option<ScreenRegion> {
+    if w <= 0 || h <= 0 {
+        return None;
+    }
+    let x0 = x.max(0) as u32;
+    let y0 = y.max(0) as u32;
+    let x1 = (x + w).max(0) as u32;
+    let y1 = (y + h).max(0) as u32;
+    if x1 <= x0 || y1 <= y0 {
+        return None;
+    }
+    Some(ScreenRegion {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    })
 }
 
 pub fn select_region(prompt: &str) -> Result<ScreenRegion> {

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -5,7 +5,7 @@ pub struct ScreenshotData {
     pub width: usize,
     pub pixels: Vec<u8>,
     /// Absolute screen coordinate of pixel (0, 0) — the capture region origin.
-    pub origin: (u32, u32),
+    pub origin: (i32, i32),
 }
 
 impl ScreenshotData {
@@ -45,17 +45,17 @@ impl ScreenshotData {
 
     /// Absolute screen coordinate of a frame pixel. Use for click targets.
     pub fn frame_to_screen(&self, x: u32, y: u32) -> (i32, i32) {
-        ((self.origin.0 + x) as i32, (self.origin.1 + y) as i32)
+        (self.origin.0 + x as i32, self.origin.1 + y as i32)
     }
 
     /// Frame pixel for an absolute screen coordinate. None if outside the frame.
     pub fn screen_to_frame(&self, sx: u32, sy: u32) -> Option<(u32, u32)> {
-        let (ox, oy) = self.origin;
-        let (dx, dy) = (sx.checked_sub(ox)?, sy.checked_sub(oy)?);
-        if dx as usize >= self.width || dy as usize >= self.height {
+        let dx = sx as i64 - self.origin.0 as i64;
+        let dy = sy as i64 - self.origin.1 as i64;
+        if dx < 0 || dy < 0 || dx as usize >= self.width || dy as usize >= self.height {
             return None;
         }
-        Some((dx, dy))
+        Some((dx as u32, dy as u32))
     }
 }
 
@@ -229,7 +229,7 @@ fn union(parent: &mut [u32], a: u32, b: u32) -> u32 {
 mod tests {
     use super::*;
 
-    fn make_frame(w: usize, h: usize, ox: u32, oy: u32, fill: u32) -> ScreenshotData {
+    fn make_frame(w: usize, h: usize, ox: i32, oy: i32, fill: u32) -> ScreenshotData {
         let mut pixels = vec![0u8; w * h * 4];
         for y in 0..h {
             for x in 0..w {


### PR DESCRIPTION
Fixes the Calibrate tab:

1. **Selector was clipped** — the preview captured the current game-window region, so you could only ever make it smaller. Now captures the full virtual desktop on both platforms (grim all-outputs / GDI BitBlt), and drag coordinates map through the actual drawn rect (the old centered-origin guess misplaced selections).

2. **Right-click shortcuts** — right-click the preview for "Select whole window under cursor" / "Select whole monitor under cursor", applied to the chosen region target:
   - Windows: WindowFromPoint/GetWindowRect, MonitorFromPoint/GetMonitorInfo
   - Wayland: hyprctl clients|monitors -j (graceful fallback elsewhere)

Also: ScreenshotData.origin is i32 (correct mapping when monitors sit left/above the primary; fixes a latent wrap bug in the WGC window capture).

Verified: Linux 19 tests + clippy clean, windows-gnu target 0 errors, GUI launches, hyprctl JSON shape matches the parser.