### PR TITLE
feat: first-run setup wizard, health tab, doctor command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -205,7 +205,7 @@ impl App {
     }
 
     #[cfg(target_os = "linux")]
-    fn calibrate_pointer(&self) -> anyhow::Result<()> {
+    pub(crate) fn calibrate_pointer(&self) -> anyhow::Result<()> {
         const D: i32 = 400; // device units; large enough that the two cursor
         // positions cannot overlap even at max deceleration
         println!("Measuring pointer scale. Do not move the mouse or type.");
@@ -910,6 +910,26 @@ impl App {
             }
             Some("version") | Some("--version") => {
                 println!("little_oil v{}", env!("CARGO_PKG_VERSION"));
+                return Ok(());
+            }
+            Some("doctor") => {
+                // checkhealth-style diagnostics; exits non-zero on any Error.
+                let checks = crate::health::run(&self);
+                for c in &checks {
+                    let tag = match c.status {
+                        crate::health::CheckStatus::Good => "[ OK ]",
+                        crate::health::CheckStatus::Warn => "[WARN]",
+                        crate::health::CheckStatus::Error => "[ ERR]",
+                    };
+                    println!("{tag} {:<20} {}", c.name, c.message);
+                }
+                let errors = checks
+                    .iter()
+                    .filter(|c| c.status == crate::health::CheckStatus::Error)
+                    .count();
+                if errors > 0 {
+                    bail!("{errors} check(s) failed");
+                }
                 return Ok(());
             }
             Some("sort") => {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -7,9 +7,12 @@
 //!
 //! Tabs:
 //! * **Actions** — empty inventory (left/right), recalibrate colors, log.
+//! * **Setup** — guided first-run wizard: detect window, drag regions, sample
+//!   inventory colors, calibrate pointer.
 //! * **Calibrate** — capture the game window, drag a rectangle, save it as a
 //!   region (game/inventory/stash/map), re-sample inventory colors.
 //! * **Inventory** — capture + live occupied-slot overlay.
+//! * **Health** — checkhealth-style diagnostics (also `little_oil doctor`).
 //! * **Settings** — edit region numbers, pointer scale, focus clicks.
 
 use crate::app::App;
@@ -68,6 +71,19 @@ struct Preview {
     /// renders it) — used to map display-space drags to image pixels.
     rect: egui::Rect,
 }
+
+/// Wizard progress. `step` is the current wizard step index (0..=5).
+struct SetupState {
+    step: usize,
+    /// Result of the last "Detect game window" press.
+    detected_window: Option<ScreenRegion>,
+    /// True once the user pressed "Detect game window" — "Not found" only
+    /// shows after an actual attempt.
+    detect_tried: bool,
+    /// Wizard step a desktop capture was last auto-attempted for: one attempt
+    /// per step entry, so a failing capture doesn't spam the log every frame.
+    last_captured_step: Option<usize>,
+}
 struct LittleOilGui {
     app: Arc<App>,
     state: Arc<Mutex<GuiState>>,
@@ -83,6 +99,9 @@ struct LittleOilGui {
     region_target: RegionTarget,
     show_inv_overlay: bool,
     status: String,
+    setup: SetupState,
+    health_checks: Option<Vec<crate::health::Check>>,
+    last_tab: &'static str,
 
     // Windows-only: system tray + global hotkeys. Kept here (the event-loop
     // thread) because both are !Send/!Sync on Windows.
@@ -97,17 +116,27 @@ impl LittleOilGui {
         let state = Arc::new(Mutex::new(GuiState {
             log: VecDeque::new(),
         }));
+        let first_run = !app.settings.read().setup_complete;
+        let tab = if first_run { "Setup" } else { "Actions" };
         let mut this = LittleOilGui {
             app,
             state,
             busy: Arc::new(AtomicBool::new(false)),
-            tab: "Actions",
+            tab,
             preview: None,
             drag: None,
             right_click_screen: None,
             region_target: RegionTarget::Game,
             show_inv_overlay: false,
             status: String::new(),
+            setup: SetupState {
+                step: 0,
+                detected_window: None,
+                detect_tried: false,
+                last_captured_step: None,
+            },
+            health_checks: None,
+            last_tab: tab,
             #[cfg(target_os = "windows")]
             tray: None,
             #[cfg(target_os = "windows")]
@@ -373,76 +402,7 @@ impl LittleOilGui {
         ui.label(
             "Drag to select a region. Right-click the preview to select a whole window or monitor.",
         );
-        if self.preview.is_some() {
-            // Short borrows only — the interaction handlers below take &mut self.
-            let shown = self.preview.as_ref().map(|p| p.shown).unwrap_or_default();
-            let (rect, response) = ui.allocate_exact_size(shown, egui::Sense::click_and_drag());
-            if let Some(prev) = &mut self.preview {
-                prev.rect = rect;
-            }
-            if let Some(prev) = &self.preview {
-                ui.painter().image(
-                    prev.texture.id(),
-                    rect,
-                    egui::Rect::from_min_max(egui::Pos2::ZERO, egui::Pos2::new(1.0, 1.0)),
-                    egui::Color32::WHITE,
-                );
-            }
-            if response.drag_started() {
-                let pos = response.interact_pointer_pos().unwrap_or_default();
-                self.drag = Some((pos, pos));
-            }
-            if response.dragged()
-                && let (Some(drag), Some(cur)) =
-                    (self.drag.as_mut(), response.interact_pointer_pos())
-            {
-                drag.1 = cur;
-            }
-            if response.drag_stopped() {
-                if let Some(cur) = response.interact_pointer_pos() {
-                    let anchor = self.drag.unwrap_or((cur, cur)).0;
-                    self.drag = Some((anchor, cur));
-                }
-                self.save_dragged_region();
-            }
-            if response.secondary_clicked() {
-                self.right_click_screen = response
-                    .interact_pointer_pos()
-                    .and_then(|p| self.screen_point_of(p));
-            }
-            // Right-click context menu: select the whole window or monitor.
-            response.context_menu(|ui| {
-                if ui.button("Select whole window under cursor").clicked() {
-                    if let Some((sx, sy)) = self.right_click_screen {
-                        self.select_whole_window(sx, sy);
-                    }
-                    ui.close();
-                }
-                if ui.button("Select whole monitor under cursor").clicked() {
-                    if let Some((sx, sy)) = self.right_click_screen {
-                        self.select_whole_monitor(sx, sy);
-                    }
-                    ui.close();
-                }
-            });
-            // Draw the drag overlay.
-            if let Some((a, b)) = self.drag {
-                let r = egui::Rect::from_two_pos(a, b);
-                ui.painter().rect_stroke(
-                    r,
-                    0.0,
-                    egui::Stroke::new(2.0_f32, egui::Color32::LIGHT_BLUE),
-                    egui::StrokeKind::Outside,
-                );
-                ui.painter().text(
-                    r.max + egui::vec2(4.0, 0.0),
-                    egui::Align2::LEFT_TOP,
-                    self.region_target.label(),
-                    egui::FontId::monospace(12.0),
-                    egui::Color32::LIGHT_BLUE,
-                );
-            }
-        } else {
+        if !self.preview_and_drag(ui) {
             ui.weak("No capture yet — click \"Capture game window\".");
         }
         ui.add_space(8.0);
@@ -465,6 +425,83 @@ impl LittleOilGui {
                 "Inventory colors not sampled — run \"Recalibrate inventory colors\" after setting the inventory region.",
             );
         }
+    }
+
+    /// Render the captured desktop and handle drag-select + right-click
+    /// selection (whole window/monitor). Returns false when there is no
+    /// preview — the caller shows its own hint.
+    fn preview_and_drag(&mut self, ui: &mut egui::Ui) -> bool {
+        let Some(_) = &self.preview else {
+            return false;
+        };
+        // Short borrows only — the interaction handlers below take &mut self.
+        let shown = self.preview.as_ref().map(|p| p.shown).unwrap_or_default();
+        let (rect, response) = ui.allocate_exact_size(shown, egui::Sense::click_and_drag());
+        if let Some(prev) = &mut self.preview {
+            prev.rect = rect;
+        }
+        if let Some(prev) = &self.preview {
+            ui.painter().image(
+                prev.texture.id(),
+                rect,
+                egui::Rect::from_min_max(egui::Pos2::ZERO, egui::Pos2::new(1.0, 1.0)),
+                egui::Color32::WHITE,
+            );
+        }
+        if response.drag_started() {
+            let pos = response.interact_pointer_pos().unwrap_or_default();
+            self.drag = Some((pos, pos));
+        }
+        if response.dragged()
+            && let (Some(drag), Some(cur)) = (self.drag.as_mut(), response.interact_pointer_pos())
+        {
+            drag.1 = cur;
+        }
+        if response.drag_stopped() {
+            if let Some(cur) = response.interact_pointer_pos() {
+                let anchor = self.drag.unwrap_or((cur, cur)).0;
+                self.drag = Some((anchor, cur));
+            }
+            self.save_dragged_region();
+        }
+        if response.secondary_clicked() {
+            self.right_click_screen = response
+                .interact_pointer_pos()
+                .and_then(|p| self.screen_point_of(p));
+        }
+        // Right-click context menu: select the whole window or monitor.
+        response.context_menu(|ui| {
+            if ui.button("Select whole window under cursor").clicked() {
+                if let Some((sx, sy)) = self.right_click_screen {
+                    self.select_whole_window(sx, sy);
+                }
+                ui.close();
+            }
+            if ui.button("Select whole monitor under cursor").clicked() {
+                if let Some((sx, sy)) = self.right_click_screen {
+                    self.select_whole_monitor(sx, sy);
+                }
+                ui.close();
+            }
+        });
+        // Draw the drag overlay.
+        if let Some((a, b)) = self.drag {
+            let r = egui::Rect::from_two_pos(a, b);
+            ui.painter().rect_stroke(
+                r,
+                0.0,
+                egui::Stroke::new(2.0_f32, egui::Color32::LIGHT_BLUE),
+                egui::StrokeKind::Outside,
+            );
+            ui.painter().text(
+                r.max + egui::vec2(4.0, 0.0),
+                egui::Align2::LEFT_TOP,
+                self.region_target.label(),
+                egui::FontId::monospace(12.0),
+                egui::Color32::LIGHT_BLUE,
+            );
+        }
+        true
     }
 
     fn ui_inventory(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
@@ -570,6 +607,339 @@ impl LittleOilGui {
         }
     }
 
+    /// Whether the wizard's pointer-calibration step should be shown at all.
+    /// Absolute-positioning platforms (niri on Linux, Windows) never need it.
+    #[cfg(target_os = "linux")]
+    fn wizard_pointer_step_needed(&self) -> bool {
+        !self.app.platform().uses_absolute_pointer()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn wizard_pointer_step_needed(&self) -> bool {
+        false
+    }
+
+    /// Capture a fresh desktop preview once per wizard step entry, so a
+    /// failing capture doesn't retry (and spam the log) every frame.
+    fn auto_capture_once(&mut self, ctx: &egui::Context) {
+        if self.preview.is_none() && self.setup.last_captured_step != Some(self.setup.step) {
+            self.capture_preview(ctx);
+            self.setup.last_captured_step = Some(self.setup.step);
+        }
+    }
+
+    /// Guided first-run setup. Auto-selected when `setup_complete` is false;
+    /// always re-runnable from the tab bar. Reuses the Calibrate tab's drag
+    /// machinery (preview_and_drag) so the wizard and manual calibration can
+    /// never drift apart.
+    fn ui_setup(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        ui.heading("Setup");
+        if self.app.settings.read().setup_complete {
+            ui.colored_label(
+                egui::Color32::from_rgb(120, 200, 120),
+                "✓ Setup complete — you can redo any step below.",
+            );
+        }
+        ui.label(format!("Step {} of 5", self.setup.step + 1));
+        ui.add_space(6.0);
+        match self.setup.step {
+            0 => {
+                ui.label("Launch Path of Exile (any window mode) before continuing.");
+                ui.add_space(4.0);
+                if ui
+                    .button("Detect game window")
+                    .on_hover_text("Finds the Path of Exile window on this desktop")
+                    .clicked()
+                {
+                    self.setup.detected_window = self.app.platform().find_game_window();
+                    self.setup.detect_tried = true;
+                }
+                ui.add_space(4.0);
+                match self.setup.detected_window {
+                    Some(r) => {
+                        ui.label(format!(
+                            "Found: {}x{} @ ({}, {})",
+                            r.width, r.height, r.x, r.y
+                        ));
+                        if ui.button("Use this window").clicked() {
+                            if let Some(r) = self.setup.detected_window.take() {
+                                self.apply_selected_region(RegionTarget::Game, r, "setup");
+                            }
+                            self.setup.step = 1;
+                        }
+                    }
+                    None if self.setup.detect_tried => {
+                        ui.colored_label(
+                            egui::Color32::from_rgb(220, 160, 60),
+                            "Not found — open the game and retry, or continue and drag it manually.",
+                        );
+                    }
+                    None => {}
+                }
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .button("Continue without detecting")
+                        .on_hover_text("You'll drag the game window region on the next step")
+                        .clicked()
+                    {
+                        self.setup.detected_window = None;
+                        self.setup.detect_tried = false;
+                        self.setup.step = 1;
+                    }
+                    if ui
+                        .button("Skip setup")
+                        .on_hover_text("Close the wizard — re-open it from the Setup tab anytime")
+                        .clicked()
+                    {
+                        self.setup.step = 0;
+                        self.setup.detected_window = None;
+                        self.setup.detect_tried = false;
+                        self.tab = "Actions";
+                    }
+                });
+            }
+            1 => {
+                self.region_target = RegionTarget::Game;
+                self.auto_capture_once(ctx);
+                ui.label("Drag a rectangle around the whole game window, then press Continue.");
+                ui.horizontal(|ui| {
+                    if ui.button("Capture desktop").clicked() {
+                        self.capture_preview(ctx);
+                    }
+                });
+                ui.add_space(4.0);
+                if !self.preview_and_drag(ui) {
+                    ui.weak("No capture yet — press \"Capture desktop\".");
+                }
+                let game_set = self.app.settings.read().game_window_region.is_some();
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Back").clicked() {
+                        self.setup.step = 0;
+                    }
+                    if ui
+                        .add_enabled(game_set, egui::Button::new("Continue"))
+                        .on_hover_text("Needs a game window region — drag one above first")
+                        .clicked()
+                    {
+                        self.setup.step = 2;
+                    }
+                });
+            }
+            2 => {
+                self.region_target = RegionTarget::Inventory;
+                self.auto_capture_once(ctx);
+                ui.label("Open your inventory in the game and leave it EMPTY, then drag a rectangle around the 12x5 grid.");
+                ui.horizontal(|ui| {
+                    if ui.button("Capture desktop").clicked() {
+                        self.capture_preview(ctx);
+                    }
+                });
+                ui.add_space(4.0);
+                if !self.preview_and_drag(ui) {
+                    ui.weak("No capture yet — press \"Capture desktop\".");
+                }
+                let inv_set = self.app.settings.read().inv_region.is_some();
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Back").clicked() {
+                        self.setup.step = 1;
+                    }
+                    if ui
+                        .add_enabled(inv_set, egui::Button::new("Continue"))
+                        .on_hover_text("Needs an inventory region — drag one above first")
+                        .clicked()
+                    {
+                        self.setup.step = 3;
+                    }
+                });
+            }
+            3 => {
+                ui.label("Keep the inventory open and empty, then press Recalibrate. Do not move the mouse while it runs.");
+                ui.add_space(4.0);
+                if ui
+                    .button("Recalibrate inventory colors")
+                    .on_hover_text(
+                        "Samples the 60 empty-slot probe colors from the inventory region",
+                    )
+                    .clicked()
+                {
+                    self.run_action("recalibrate", |app| app.reset_inv_colors());
+                }
+                ui.add_space(4.0);
+                let n = self
+                    .app
+                    .settings
+                    .read()
+                    .inv_samples
+                    .as_ref()
+                    .map(|v| v.len());
+                match n {
+                    Some(60) => {
+                        ui.colored_label(egui::Color32::from_rgb(120, 200, 120), "60/60 — done");
+                    }
+                    Some(k) => {
+                        ui.label(format!("samples: {k}/60"));
+                    }
+                    None => {
+                        ui.weak("samples: 0/60 — not sampled yet");
+                    }
+                }
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Back").clicked() {
+                        self.setup.step = 2;
+                    }
+                    if ui
+                        .add_enabled(n == Some(60), egui::Button::new("Continue"))
+                        .on_hover_text(
+                            "Needs 60 color samples — Recalibrate with an empty inventory first",
+                        )
+                        .clicked()
+                    {
+                        self.setup.step = if self.wizard_pointer_step_needed() {
+                            4
+                        } else {
+                            5
+                        };
+                    }
+                });
+            }
+            4 => {
+                ui.label("Calibrates how far the mouse moves per click. It moves the mouse for ~3 seconds — close animated windows and don't touch the mouse.");
+                ui.add_space(4.0);
+                #[cfg(target_os = "linux")]
+                if ui
+                    .button("Calibrate pointer")
+                    .on_hover_text("Measures pointer_scale by diffing cursor positions before/after a raw move")
+                    .clicked()
+                {
+                    self.run_action("calibrate-pointer", |app| app.calibrate_pointer());
+                }
+                ui.add_space(4.0);
+                if let Some(s) = self.app.settings.read().pointer_scale {
+                    ui.label(format!("pointer_scale = {s:.4}"));
+                }
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Back").clicked() {
+                        self.setup.step = 3;
+                    }
+                    if ui
+                        .button("Skip")
+                        .on_hover_text("Skip calibration — re-run Setup or calibrate-pointer later")
+                        .clicked()
+                    {
+                        self.setup.step = 5;
+                    }
+                    if ui.button("Continue").clicked() {
+                        self.setup.step = 5;
+                    }
+                });
+            }
+            _ => {
+                let s = self.app.settings.read();
+                let game = s
+                    .game_window_region
+                    .map(|r| format!("{}x{} @ ({}, {})", r.width, r.height, r.x, r.y))
+                    .unwrap_or_else(|| "not set".into());
+                let inv = s
+                    .inv_region
+                    .map(|r| format!("{}x{} @ ({}, {})", r.width, r.height, r.x, r.y))
+                    .unwrap_or_else(|| "not set".into());
+                let samples = s.inv_samples.as_ref().map(|v| v.len()).unwrap_or(0);
+                let focus = s.focus_clicks;
+                let scale = if self.wizard_pointer_step_needed() {
+                    s.pointer_scale
+                        .map(|v| format!("{v:.4}"))
+                        .unwrap_or_else(|| "not calibrated — redo step 4".into())
+                } else {
+                    "absolute positioning — not needed".into()
+                };
+                drop(s);
+                ui.add_space(4.0);
+                ui.label(format!("Game window: {game}"));
+                ui.label(format!("Inventory grid: {inv}"));
+                ui.label(format!("Color samples: {samples}/60"));
+                ui.label(format!("Focus clicks: {focus}"));
+                ui.label(format!("Pointer scale: {scale}"));
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Back").clicked() {
+                        self.setup.step = if self.wizard_pointer_step_needed() {
+                            4
+                        } else {
+                            3
+                        };
+                    }
+                    if ui
+                        .button("Finish")
+                        .on_hover_text("Mark setup complete and open the Actions tab")
+                        .clicked()
+                    {
+                        {
+                            let mut w = self.app.settings.write();
+                            w.setup_complete = true;
+                        }
+                        let snapshot = self.app.settings.read().clone();
+                        let path = config_path().unwrap_or_else(|_| "config.json".into());
+                        if let Err(e) = save_config(&path, &snapshot) {
+                            self.push(format!("config write failed: {e:#}"));
+                        } else {
+                            self.push("Setup complete — you can use the Actions tab now");
+                        }
+                        self.setup.step = 0;
+                        self.setup.detected_window = None;
+                        self.setup.detect_tried = false;
+                        self.tab = "Actions";
+                    }
+                });
+            }
+        }
+    }
+
+    /// checkhealth-style diagnostics — the same checks `little_oil doctor`
+    /// runs, rendered as colored rows. Re-runs on every visit and on demand.
+    fn ui_health(&mut self, ui: &mut egui::Ui) {
+        ui.heading("Health");
+        ui.label("Diagnostics, checkhealth-style. Fix any red items, then re-run.");
+        if self.health_checks.is_none()
+            || ui
+                .button("Re-run checks")
+                .on_hover_text("Re-run every health check now")
+                .clicked()
+        {
+            self.health_checks = Some(crate::health::run(&self.app));
+        }
+        ui.add_space(6.0);
+        let Some(checks) = &self.health_checks else {
+            return;
+        };
+        for c in checks {
+            let (color, tag) = match c.status {
+                crate::health::CheckStatus::Good => (egui::Color32::from_rgb(120, 200, 120), "✓"),
+                crate::health::CheckStatus::Warn => (egui::Color32::from_rgb(220, 160, 60), "△"),
+                crate::health::CheckStatus::Error => (egui::Color32::from_rgb(220, 60, 60), "✗"),
+            };
+            ui.horizontal(|ui| {
+                ui.colored_label(color, tag);
+                ui.monospace(format!("{:<18}", c.name));
+                ui.label(&c.message);
+            });
+        }
+        if checks
+            .iter()
+            .any(|c| c.status == crate::health::CheckStatus::Error)
+        {
+            ui.add_space(6.0);
+            ui.colored_label(
+                egui::Color32::from_rgb(220, 60, 60),
+                "Some checks failed — open the Setup tab to fix them.",
+            );
+        }
+    }
+
     fn ui_settings(&mut self, ui: &mut egui::Ui) {
         ui.heading("Settings");
         ui.label("Regions are in screen pixels. Calibrate them with the drag-select on the Calibrate tab instead of typing numbers.");
@@ -665,16 +1035,28 @@ impl eframe::App for LittleOilGui {
         self.pump_tray_events();
         #[cfg(target_os = "windows")]
         self.pump_hotkey_events();
+        if self.tab != self.last_tab {
+            self.last_tab = self.tab;
+            self.health_checks = None; // re-run on next visit to Health
+        }
         egui::TopBottomPanel::top("tabs").show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.label("Little Oil");
                 for (tab, hint) in [
                     ("Actions", "Run the inventory macros"),
                     (
+                        "Setup",
+                        "Guided first-run setup — detect window, regions, colors",
+                    ),
+                    (
                         "Calibrate",
                         "Drag-select regions; right-click a preview for whole window/monitor",
                     ),
                     ("Inventory", "Preview the inventory overlay"),
+                    (
+                        "Health",
+                        "Diagnose why something isn't working (checkhealth-style)",
+                    ),
                     ("Settings", "Tune behavior and find the config file"),
                 ] {
                     ui.selectable_value(&mut self.tab, tab, tab)
@@ -686,8 +1068,10 @@ impl eframe::App for LittleOilGui {
         });
         egui::CentralPanel::default().show(ctx, |ui| match self.tab {
             "Actions" => self.ui_actions(ui),
+            "Setup" => self.ui_setup(ui, ctx),
             "Calibrate" => self.ui_calibrate(ui, ctx),
             "Inventory" => self.ui_inventory(ui, ctx),
+            "Health" => self.ui_health(ui),
             _ => self.ui_settings(ui),
         });
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,328 @@
+//! `little_oil doctor` and the GUI Health tab share these checks.
+//!
+//! Every check is read-only: no clicks, no injection, no config writes — safe
+//! to run while the game is open. The CLI prints the checks with `[ OK ]` /
+//! `[WARN]` / `[ ERR]` tags and exits non-zero on any Error; the GUI Health
+//! tab renders the same list.
+use crate::ScreenRegion;
+use crate::app::App;
+use crate::platform::Platform;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Good,
+    Warn,
+    Error,
+}
+
+pub struct Check {
+    pub name: &'static str,
+    pub status: CheckStatus,
+    pub message: String,
+}
+
+fn ok(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Good,
+        message: message.into(),
+    }
+}
+
+fn warn(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Warn,
+        message: message.into(),
+    }
+}
+
+fn err(name: &'static str, message: impl Into<String>) -> Check {
+    Check {
+        name,
+        status: CheckStatus::Error,
+        message: message.into(),
+    }
+}
+
+/// True when `region` is fully inside the rect [ox, ox+w) x [oy, oy+h).
+/// i64 arithmetic so overflowing i32 sums (pathological regions) compare
+/// correctly instead of wrapping.
+pub fn region_inside(region: ScreenRegion, ox: i32, oy: i32, w: u32, h: u32) -> bool {
+    let x0 = region.x as i64;
+    let y0 = region.y as i64;
+    let x1 = x0 + region.width as i64;
+    let y1 = y0 + region.height as i64;
+    x0 >= ox as i64 && y0 >= oy as i64 && x1 <= ox as i64 + w as i64 && y1 <= oy as i64 + h as i64
+}
+
+/// Run every health check in order. Single source of truth for both the CLI
+/// `doctor` command and the GUI Health tab.
+pub fn run(app: &App) -> Vec<Check> {
+    let mut checks = Vec::new();
+    let s = app.settings.read();
+    let platform = app.platform();
+
+    // 1. Platform.
+    checks.push(match platform {
+        Platform::Wayland => ok("platform", "wayland"),
+        Platform::Windows => ok("platform", "windows"),
+        Platform::X11 => err(
+            "platform",
+            "X11 is only a compile-time shim — set \"platform\": \"wayland\" in config, \
+             or run on Windows",
+        ),
+    });
+
+    // 2. Config file readable and writable.
+    match crate::config_path() {
+        Err(e) => checks.push(err("config", format!("{e:#}"))),
+        Ok(path) => match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+        {
+            Err(e) => checks.push(err(
+                "config",
+                format!("cannot open {}: {e}", path.display()),
+            )),
+            Ok(_) => checks.push(ok("config", format!("{}", path.display()))),
+        },
+    }
+
+    // 3. Desktop capture — also feeds the region-bounds check.
+    let capture = platform.capture_desktop();
+    let bounds: Option<(i32, i32, u32, u32)> = match &capture {
+        Err(e) => {
+            checks.push(err("desktop-capture", format!("{e:#}")));
+            None
+        }
+        Ok(d) if d.width == 0 || d.height == 0 => {
+            checks.push(err("desktop-capture", "capture returned an empty image"));
+            None
+        }
+        Ok(d) => {
+            checks.push(ok(
+                "desktop-capture",
+                format!(
+                    "{}x{} (origin {}, {})",
+                    d.width, d.height, d.origin.0, d.origin.1
+                ),
+            ));
+            Some((d.origin.0, d.origin.1, d.width as u32, d.height as u32))
+        }
+    };
+
+    // 4. Game window on screen?
+    match platform.find_game_window() {
+        Some(r) => checks.push(ok(
+            "game-window",
+            format!("found at {}x{} @ ({}, {})", r.width, r.height, r.x, r.y),
+        )),
+        None => match s.game_window_region {
+            Some(r) => checks.push(warn(
+                "game-window",
+                format!(
+                    "PoE window not on screen (game closed?) — saved region {}x{} @ ({}, {})",
+                    r.width, r.height, r.x, r.y
+                ),
+            )),
+            None => checks.push(err(
+                "game-window",
+                "Path of Exile window not found — launch the game first \
+                 (window detection uses hyprctl; unsupported on other compositors)",
+            )),
+        },
+    }
+
+    // 5. Regions configured?
+    for (name, region, required, missing_msg) in [
+        (
+            "region-game",
+            s.game_window_region,
+            true,
+            "not set — run the Setup wizard",
+        ),
+        (
+            "region-inv",
+            s.inv_region,
+            true,
+            "not set — run the Setup wizard",
+        ),
+        (
+            "region-stash",
+            s.stash_region,
+            false,
+            "not set — only needed for stash features",
+        ),
+        (
+            "region-map",
+            s.map_region,
+            false,
+            "not set — only needed for map features",
+        ),
+    ] {
+        match region {
+            Some(r) => checks.push(ok(
+                name,
+                format!("{}x{} @ ({}, {})", r.width, r.height, r.x, r.y),
+            )),
+            None if required => checks.push(err(name, missing_msg)),
+            None => checks.push(warn(name, missing_msg)),
+        }
+    }
+
+    // 6. Regions inside the visible desktop (and inventory inside the game).
+    if let Some((ox, oy, w, h)) = bounds {
+        let mut all_inside = true;
+        for (label, region) in [
+            ("game window", s.game_window_region),
+            ("inventory", s.inv_region),
+            ("stash", s.stash_region),
+            ("map", s.map_region),
+        ] {
+            if let Some(r) = region
+                && !region_inside(r, ox, oy, w, h)
+            {
+                all_inside = false;
+                checks.push(err(
+                    "region-bounds",
+                    format!(
+                        "{label} region {}x{} @ ({}, {}) lies outside the visible \
+                         desktop — monitors changed? re-run Setup",
+                        r.width, r.height, r.x, r.y
+                    ),
+                ));
+            }
+        }
+        if let (Some(inv), Some(game)) = (s.inv_region, s.game_window_region)
+            && !region_inside(inv, game.x as i32, game.y as i32, game.width, game.height)
+        {
+            all_inside = false;
+            checks.push(warn(
+                "region-bounds",
+                "inventory region does not lie inside the game window region — \
+                 re-drag it in Setup",
+            ));
+        }
+        if all_inside {
+            checks.push(ok(
+                "region-bounds",
+                "all regions inside the visible desktop",
+            ));
+        }
+    }
+
+    // 7. Inventory color samples.
+    match &s.inv_samples {
+        Some(v) if v.len() == 60 => checks.push(ok("inv-samples", "60 slots sampled")),
+        Some(v) => checks.push(err(
+            "inv-samples",
+            format!("expected 60 samples, found {}", v.len()),
+        )),
+        None => checks.push(err(
+            "inv-samples",
+            "inventory colors not sampled — run the Setup wizard step 3 or \
+             Recalibrate on the Actions tab",
+        )),
+    }
+
+    // 8. Focus clicks.
+    let v = s.focus_clicks;
+    checks.push(if (1..=5).contains(&v) {
+        ok("focus-clicks", format!("{v} clicks per focus"))
+    } else if v == 0 {
+        err(
+            "focus-clicks",
+            "focus_clicks=0 means macros never focus the game window — set it to 2",
+        )
+    } else {
+        warn("focus-clicks", format!("unusual value {v}"))
+    });
+
+    // 9. Pointer scale — irrelevant when the platform positions absolutely.
+    if !platform.uses_absolute_pointer() {
+        checks.push(match s.pointer_scale {
+            Some(sc) if (0.5..=3.0).contains(&sc) => ok("pointer-scale", format!("{sc:.2}")),
+            Some(sc) => warn("pointer-scale", format!("unusual value {sc}")),
+            None => warn(
+                "pointer-scale",
+                "not set — clicks may land short or overshoot; \
+                 run Setup step 4 (pointer calibration)",
+            ),
+        });
+    }
+
+    // 10. Linux external prerequisites.
+    #[cfg(target_os = "linux")]
+    {
+        for (name, bin) in [
+            ("bin-grim", "grim"),
+            ("bin-slurp", "slurp"),
+            ("bin-wl-copy", "wl-copy"),
+        ] {
+            match std::process::Command::new(bin).arg("--version").output() {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    checks.push(err(name, format!("'{bin}' not found in PATH — install it")))
+                }
+                Err(e) => checks.push(warn(name, format!("{e}"))),
+                Ok(_) => checks.push(ok(name, "found")),
+            }
+        }
+        match std::fs::OpenOptions::new().write(true).open("/dev/uinput") {
+            Ok(_) => checks.push(ok("uinput", "writable")),
+            Err(e) => checks.push(err(
+                "uinput",
+                format!(
+                    "cannot open /dev/uinput for writing — add your user to the \
+                     'input' group or set a udev rule ({e})"
+                ),
+            )),
+        }
+    }
+
+    checks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn region(x: u32, y: u32, w: u32, h: u32) -> ScreenRegion {
+        ScreenRegion {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn region_inside_positive() {
+        assert!(region_inside(region(10, 10, 100, 100), 0, 0, 2560, 1440));
+    }
+
+    #[test]
+    fn region_inside_negative_origin() {
+        // Second monitor left of the primary: its origin is -1920, 0.
+        assert!(region_inside(
+            region(0, 100, 100, 100),
+            -1920,
+            0,
+            4480,
+            1440
+        ));
+    }
+
+    #[test]
+    fn region_inside_overflows() {
+        // x1 = 2600 > 2560 — sticks out of the desktop.
+        assert!(!region_inside(region(2500, 10, 100, 100), 0, 0, 2560, 1440));
+    }
+
+    #[test]
+    fn region_inside_zero_size() {
+        // Degenerate region sits at the origin — inside, but useless.
+        assert!(region_inside(region(0, 0, 0, 0), 0, 0, 2560, 1440));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod auto_roll;
 mod chaos_recipe;
 mod dicts;
 mod gui;
+mod health;
 pub mod item;
 mod platform;
 mod screenshot;
@@ -72,6 +73,10 @@ pub struct Settings {
     /// Named clickable points (currency slots, filter button, …), screen space.
     #[serde(default)]
     pub points: Option<Vec<NamedPoint>>,
+    /// True once the GUI first-run wizard has been completed. Cosmetic only —
+    /// decides which tab the GUI opens on. Old configs load as false via serde.
+    #[serde(default)]
+    setup_complete: bool,
 }
 
 impl Settings {
@@ -136,6 +141,7 @@ fn default_settings() -> Settings {
         map_region: None,
         map_grid: None,
         points: None,
+        setup_complete: false,
     }
 }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -124,6 +124,21 @@ impl Platform {
         None
     }
 
+    /// Bounds of the Path of Exile window if it is on screen. Used by the Setup
+    /// wizard and health checks. `None` when the game is closed or the platform
+    /// cannot enumerate windows.
+    pub fn find_game_window(&self) -> Option<ScreenRegion> {
+        #[cfg(target_os = "linux")]
+        if matches!(self, Platform::Wayland) {
+            return wayland::find_game_window();
+        }
+        #[cfg(target_os = "windows")]
+        if matches!(self, Platform::Windows) {
+            return windows::find_game_window().and_then(windows::window_rect);
+        }
+        None
+    }
+
     /// Returns `true` when the platform uses absolute pointer positioning
     /// (no `pointer_scale` needed). On Linux this is niri only (wlr virtual
     /// pointer). On Windows all positioning is absolute.

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -177,6 +177,47 @@ pub fn monitor_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
     }
     None
 }
+
+/// Bounds of the Path of Exile window via `hyprctl clients -j`, matching on a
+/// case-insensitive title or class. Compositors without hyprctl return None
+/// (the Setup wizard lets the user drag the region instead).
+#[cfg(target_os = "linux")]
+pub fn find_game_window() -> Option<ScreenRegion> {
+    let out = std::process::Command::new("hyprctl")
+        .args(["clients", "-j"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let clients: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    for w in clients.as_array()?.iter() {
+        let (Some(title), Some(class)) = (w["title"].as_str(), w["class"].as_str()) else {
+            continue;
+        };
+        let hay = format!("{} {}", title, class).to_lowercase();
+        if !(hay.contains("pathofexile") || hay.contains("path of exile")) {
+            continue;
+        }
+        let (Some(at), Some(size)) = (w["at"].as_array(), w["size"].as_array()) else {
+            continue;
+        };
+        let (Some(wx), Some(wy)) = (
+            at.first().and_then(|v| v.as_i64()),
+            at.get(1).and_then(|v| v.as_i64()),
+        ) else {
+            continue;
+        };
+        let (Some(ww), Some(wh)) = (
+            size.first().and_then(|v| v.as_i64()),
+            size.get(1).and_then(|v| v.as_i64()),
+        ) else {
+            continue;
+        };
+        return region_from_bounds(wx as i32, wy as i32, ww as i32, wh as i32);
+    }
+    None
+}
 pub fn select_region(prompt: &str) -> anyhow::Result<ScreenRegion> {
     let _ = Command::new("notify-send")
         .args(["-u", "critical", "Little Oil", prompt])

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -362,6 +362,20 @@ pub fn window_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
     }
 }
 
+/// Screen bounds of an HWND (`GetWindowRect`), clamped to the non-negative
+/// quadrant like every other region. Used by `find_game_window` health checks.
+pub fn window_rect(hwnd: HWND) -> Option<ScreenRegion> {
+    unsafe {
+        use windows::Win32::Foundation::RECT;
+        use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+        let mut r = RECT::default();
+        if GetWindowRect(hwnd, &mut r as *mut _).is_err() {
+            return None;
+        }
+        clamp_region(r.left, r.top, r.right - r.left, r.bottom - r.top)
+    }
+}
+
 /// Bounds of the monitor under a screen point (`MonitorFromPoint`).
 pub fn monitor_under_point(x: i32, y: i32) -> Option<ScreenRegion> {
     unsafe {


### PR DESCRIPTION
## What
Makes the app usable by a non-technical person with zero README reading.

**Setup tab (guided first-run wizard)** — auto-opens on first run (new `setup_complete` config flag, serde-default false so existing configs load unchanged); always re-runnable. 5 steps:
1. Detect game window (hyprctl on Wayland, `GetWindowRect` on Windows)
2. Drag the game window region
3. Drag the inventory grid region
4. Sample the 60 inventory color probes (with live 60/60 progress)
5. Pointer calibration (Linux, non-absolute platforms only, with Skip)

Finish writes `setup_complete: true` and jumps to Actions.

**Health tab + `little_oil doctor`** — one shared checkhealth-style implementation (`src/health.rs`) rendered two ways:
- GUI: colored ✓/△/✗ rows, re-runs on tab entry + on demand
- CLI: `[ OK ]/[WARN]/[ ERR]` lines, exits 1 when any Error

Checks: platform (X11 → Error), config readable/writable, desktop capture, game-window detection, regions set, regions inside the visible desktop, inventory-inside-game, 60 inv samples, focus-clicks range, pointer-scale (skipped on absolute-positioning platforms), Linux prereqs (grim/slurp/wl-copy in PATH, /dev/uinput writable).

## Notes
- The wizard reuses the Calibrate tab's drag machinery via a new shared `preview_and_drag` helper — wizard and manual calibration can't drift apart; Calibrate behavior unchanged.
- `App::calibrate_pointer` is now `pub(crate)` so the wizard step can run it.
- Verified: fmt clean, 0 clippy warnings, 23/23 tests (4 new for `region_inside`), `little_oil doctor` on the Hyprland box (all OK except expected pointer-scale WARN — config has `pointer_scale: null`), windows-gnu cross-check 0 errors.
- GUI walkthrough (opens on Setup tab) needs a manual pass — the machine is in use.

Not included (out of scope): friendlier CLI error messages, settings-tab region display, GUI memory hints, versioned releases, auto-update.