### PR TITLE
ci: fix gh release step; restore Windows release upload + README

### DIFF
--- a/.github/workflows/build-linux-appimage.yml
+++ b/.github/workflows/build-linux-appimage.yml
@@ -85,6 +85,10 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$TAG" --title "Little Oil $TAG" --generate-notes --latest || true
-          gh release upload "$TAG" "little_oil-${VER}-x86_64.AppImage" --clobber
+          # jammy's gh (2.17) has no --latest/--clobber; new non-draft releases
+          # are Latest by default.
+          gh release create "$TAG" --title "Little Oil $TAG" --generate-notes || true
+          gh release upload "$TAG" "little_oil-${VER}-x86_64.AppImage"

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -11,6 +11,7 @@ name: build-windows-release
 on:
   push:
     branches: [master]
+    tags: ['v*']
   workflow_dispatch:
 
 jobs:
@@ -43,3 +44,22 @@ jobs:
           name: little_oil-windows-x86_64
           path: little_oil-windows-x86_64.zip
           if-no-files-found: error
+
+      - name: Attach to release (version tags only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The AppImage workflow creates the release; retry in case this job
+          # runs first.
+          attempt=0
+          until gh release upload "$TAG" little_oil-windows-x86_64.zip --clobber; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 10 ]; then
+              echo "release upload failed after 10 attempts" >&2
+              exit 1
+            fi
+            sleep 6
+          done

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ Every push to `master` builds the Windows exe automatically — grab it from
 `little_oil-windows-x86_64`**. Unzip anywhere and run `little_oil.exe`.
 Windows 10 2004+ is required (WGC). No extra runtime DLLs, no installer, no
 admin rights.
+On tagged releases (`v*`), the zip is also attached to the GitHub Release page.
 
 Build your own on a Windows machine (MSVC toolchain, the most conventional
 distribution build):
@@ -50,6 +51,28 @@ Settings tab → *Open config folder*).
   pixels. If the game runs at 100% scale everything matches the calibrations.
 - `set-region`/`select_region` (slurp) are Linux-only; on Windows do region
   selection from the GUI drag-select.
+
+## Linux
+
+### Install (AppImage)
+
+Prebuilt AppImages are attached to tagged releases. Download
+`little_oil-<version>-x86_64.AppImage` from the
+[latest release](https://github.com/John2143/little_oil/releases/latest),
+then:
+
+```sh
+chmod +x little_oil-0.1.0-x86_64.AppImage
+./little_oil-0.1.0-x86_64.AppImage            # needs libfuse2 on some distros
+./little_oil-0.1.0-x86_64.AppImage --appimage-extract-and-run   # fallback without FUSE
+```
+
+The AppImage bundles the app and its Wayland/X11 GUI libraries. It needs a
+glibc of 2.35 or newer (Ubuntu 22.04+, Debian 12+, Fedora 37+, Arch) — and
+the system tools and permissions under
+[Requirements (Linux)](#requirements-linux) below are still required.
+
+Build your own with the nix flake or `cargo build --release`.
 
 ## Requirements (Linux)
 


### PR DESCRIPTION
The original PR #5 accidentally committed without the Windows-workflow and README changes (a pathspec error in git add, later wiped by a reset). Restored both, and fixed the AppImage release step that failed on the v0.1.0 tag run:\n\n- jammy's gh (2.17.2) does not auto-read `GITHUB_TOKEN` in this container — pass `GH_TOKEN`/`GITHUB_TOKEN` explicitly\n- `--latest` and `--clobber` are unknown flags on gh 2.17 — dropped (new releases are Latest by default)\n- Windows workflow re-gains the v* tag trigger and zip release upload (with retry loop)