### PR TITLE
ci: pin GH_REPO for gh release steps

### DIFF
--- a/.github/workflows/build-linux-appimage.yml
+++ b/.github/workflows/build-linux-appimage.yml
@@ -87,6 +87,7 @@ jobs:
           TAG: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
+          GH_REPO: John2143/little_oil
         run: |
           # jammy's gh (2.17) has no --latest/--clobber; new non-draft releases
           # are Latest by default.

--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: John2143/little_oil
         run: |
           # The AppImage workflow creates the release; retry in case this job
           # runs first.


### PR DESCRIPTION
Run 31263733067: gh auth now works, but repo discovery fails in the container ('not a git repository'). `GH_REPO: John2143/little_oil` fixes create/upload without any git detection.